### PR TITLE
feat : 내가 받은 호감리스트에서 정렬 기능 구현

### DIFF
--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -47,20 +47,37 @@ public class NotProd {
                 Member memberUser4 = memberService.join("user4", "1234").getData();
                 Member memberUser5 = memberService.join("user5", "1234").getData();
 
-                Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__%s".formatted(kakaoDevUserOAuthId)).getData();
-                Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__%s".formatted(googleDevUserOAuthId)).getData();
-                Member memberUser7ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__%s".formatted(naverDevUserOAuthId)).getData();
-                Member memberUser8ByFacebook = memberService.whenSocialLogin("FACEBOOK", "FACEBOOK__%s".formatted(facebookDevUserOAuthId)).getData();
+                Member memberUser6ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__%s".formatted(kakaoDevUserOAuthId)).getData();
+                Member memberUser7ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__%s".formatted(googleDevUserOAuthId)).getData();
+                Member memberUser8ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__%s".formatted(naverDevUserOAuthId)).getData();
+                Member memberUser9ByFacebook = memberService.whenSocialLogin("FACEBOOK", "FACEBOOK__%s".formatted(facebookDevUserOAuthId)).getData();
 
                 instaMemberService.connect(memberUser2, "insta_user2", "M");
                 instaMemberService.connect(memberUser3, "insta_user3", "W");
                 instaMemberService.connect(memberUser4, "insta_user4", "M");
+                instaMemberService.connect(memberUser5, "insta_user5", "W");
 
-                // 원활한 테스트와 개발을 위해서 자동으로 만들어지는 호감이 삭제, 수정이 가능하도록 쿨타임해제
-                LikeablePerson likeablePersonToinstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
-                Ut.reflection.setFieldValue(likeablePersonToinstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
-                LikeablePerson likeablePersonToinstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
-                Ut.reflection.setFieldValue(likeablePersonToinstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+                instaMemberService.connect(memberUser6ByKakao, "insta_user6", "M");
+                instaMemberService.connect(memberUser7ByGoogle, "insta_user7", "W");
+                instaMemberService.connect(memberUser8ByNaver, "insta_user8", "M");
+                instaMemberService.connect(memberUser9ByFacebook, "insta_user9", "W");
+
+                LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
+                Ut.reflection.setFieldValue(likeablePersonToInstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+
+                LikeablePerson likeablePersonToInstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
+                Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+
+                LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+
+                LikeablePerson likeablePersonToInstaUser5 = likeablePersonService.like(memberUser2, "insta_user5", 2).getData();
+
+                LikeablePerson likeablePersonToInstaUser4_2 = likeablePersonService.like(memberUser2, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_3 = likeablePersonService.like(memberUser5, "insta_user4", 3).getData();
+                LikeablePerson likeablePersonToInstaUser4_4 = likeablePersonService.like(memberUser6ByKakao, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_5 = likeablePersonService.like(memberUser7ByGoogle, "insta_user4", 1).getData();
+                LikeablePerson likeablePersonToInstaUser4_6 = likeablePersonService.like(memberUser8ByNaver, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_7 = likeablePersonService.like(memberUser9ByFacebook, "insta_user4", 3).getData();
 
             }
         };

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -126,32 +126,7 @@ public class LikeablePersonController {
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
 
-            // 해당 인스타회원이 좋아하는 사람들 목록
-            Stream<LikeablePerson> likeablePeopleStream = instaMember.getToLikeablePeople().stream();
-
-            if(gender != null) {
-                if(gender.equals("W")) {
-                    likeablePeopleStream = likeablePeopleStream.filter(e -> e.getFromInstaMember()
-                                                                            .getGender()
-                                                                            .equals("W"));
-                }
-                else {
-                    likeablePeopleStream = likeablePeopleStream.filter(e -> e.getFromInstaMember()
-                                                                            .getGender()
-                                                                            .equals("M"));
-                }
-            }
-
-            if(attractiveTypeCode != 0) {
-                likeablePeopleStream = switch (attractiveTypeCode) {
-                    case 1 -> likeablePeopleStream.filter(e -> e.getAttractiveTypeCode() == 1);
-                    case 2 -> likeablePeopleStream.filter(e -> e.getAttractiveTypeCode() == 2);
-                    case 3 -> likeablePeopleStream.filter(e -> e.getAttractiveTypeCode() == 3);
-                    default -> likeablePeopleStream;
-                };
-            }
-
-            List<LikeablePerson> likeablePeople = likeablePeopleStream.collect(Collectors.toList());
+            List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember(instaMember, gender, attractiveTypeCode, sortCode);
 
             model.addAttribute("likeablePeople", likeablePeople);
         }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -15,9 +15,11 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -213,5 +215,39 @@ public class LikeablePersonService {
 
 
         return RsData.of("S-1", "호감정보 취소가 가능합니다.");
+    }
+
+    public List<LikeablePerson> findByToInstaMember(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
+        Stream<LikeablePerson> likeablePeopleStream = instaMember.getToLikeablePeople().stream();
+
+        if (gender != null) {
+            likeablePeopleStream = likeablePeopleStream
+                .filter(likeablePerson -> likeablePerson.getFromInstaMember().getGender().equals(gender));
+        }
+
+        if(attractiveTypeCode != 0) {
+            likeablePeopleStream = likeablePeopleStream
+                .filter(likeablePerson -> likeablePerson.getAttractiveTypeCode() == attractiveTypeCode);
+        }
+
+        likeablePeopleStream = switch (sortCode) {
+            case 2 -> likeablePeopleStream
+                .sorted(Comparator.comparing(LikeablePerson::getId));
+            case 3 -> likeablePeopleStream
+                .sorted(Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes()).reversed()
+                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed()));
+            case 4 -> likeablePeopleStream
+                .sorted(Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes())
+                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed()));
+            case 5 -> likeablePeopleStream
+                .sorted(Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getGender()).reversed()
+                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed()));
+            case 6 -> likeablePeopleStream
+                .sorted(Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
+                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed()));
+            default -> likeablePeopleStream;
+        };
+
+        return likeablePeopleStream.toList();
     }
 }

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -1,5 +1,4 @@
 <html data-theme="light" lang="ko">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport"


### PR DESCRIPTION
- [x] 최신순(기본) 정렬 - 최근에 받은 호감표시를 우선적으로 표시

- [x] 날짜순 - 오래전에 받은 호감표시를 우선적으로 표시

- [x] 인기 많은 순 - 인기가 많은 사람의 호감표시를 우선적으로 표시

- [x] 인기 적은 순 - 인기가 적은 사람의 호감표시를 우선적으로 표시

- [x] 성별순 - 여성에게 받은 호감표시를 먼저 표시하고, 그 다음 남자에게 받은 호감표시를 후에 표시

- [x] 호감사유순 - 외모 때문에 받은 호감표시를 먼저 표시하고, 
그 다음 성격 때문에 받은 호감표시를 후에 표시, 
마지막으로 능력 때문에 받은 호감표시를 후에 표시